### PR TITLE
fix: corrige listagem de livros ao excluir um livro

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const confirmar = confirm("Tem certeza que deseja excluir esse livro?")
     if (confirmar) {
       livros = livros.filter(livro => livro.id !== idLivro);
+      renderizarLivros();
     }
   }
 


### PR DESCRIPTION
## Principais mudanças corrigidas
- Ao clicar para excluir um determinado livro, este não saia da lista de livros.
- Foi adcionado a chamada da função rederizarLivros() dentro da função de remover livros. 